### PR TITLE
Enable or disable cross-origin resource sharing, i.e. whether a browser ...

### DIFF
--- a/templates/etc/elasticsearch/elasticsearch.yml.erb
+++ b/templates/etc/elasticsearch/elasticsearch.yml.erb
@@ -231,6 +231,15 @@ bootstrap.mlockall: <%= @mlock %>
 #
 # http.enabled: false
 
+# Enable or disable cross-origin resource sharing, i.e. whether a browser on another origin can do requests to Elasticsearch. Defaults to false.
+#
+http.cors.enabled: <%= @http_cors_enabled  %>
+
+# Which origins to allow. Defaults to *, i.e. any origin. If you prepend and append a / to the value, 
+# this will be treated as a regular expression, allowing you to support HTTP and HTTPs. 
+# for example using /https?:\/\/localhost(:[0-9]+)?/ would return the request header appropriately in both cases.
+#
+http.cors.allow-origin: <%= @http_cors_origin %>
 
 ################################### Gateway ###################################
 


### PR DESCRIPTION
...on another origin can do requests to Elasticsearch.